### PR TITLE
CMake: implement scope and end fields for functions and macros

### DIFF
--- a/Units/parser-cmake.r/cmake-function.d/args.ctags
+++ b/Units/parser-cmake.r/cmake-function.d/args.ctags
@@ -1,0 +1,1 @@
+--fields=+ne

--- a/Units/parser-cmake.r/cmake-function.d/expected.tags
+++ b/Units/parser-cmake.r/cmake-function.d/expected.tags
@@ -1,5 +1,8 @@
-Bfunctiontag_this_2	input.cmake	/^	function(	Bfunctiontag_this_2 ${BAR})$/;"	f
-cxx_shared_library	input.cmake	/^function(cxx_shared_library name cxx_flags)$/;"	f
-d_ALSO_Tag_this	input.cmake	/^        d_ALSO_Tag_this$/;"	f
-eLastlyTagThis_	input.cmake	/^eLastlyTagThis_ "hello")$/;"	f
-tag_this1	input.cmake	/^function(tag_this1)$/;"	f
+Bfunctiontag_this_2	input.cmake	/^	function(	Bfunctiontag_this_2 ${BAR})$/;"	f	line:9	end:25
+a	input.cmake	/^function(a)$/;"	f	line:3	end:8
+b	input.cmake	/^  function(b)$/;"	f	line:4	function:a	end:7
+c	input.cmake	/^    function(c)$/;"	f	line:5	function:a.b	end:6
+cxx_shared_library	input.cmake	/^function(cxx_shared_library name cxx_flags)$/;"	f	line:11	function:Bfunctiontag_this_2	end:13
+d_ALSO_Tag_this	input.cmake	/^        d_ALSO_Tag_this$/;"	f	line:16	function:Bfunctiontag_this_2	end:25
+eLastlyTagThis_	input.cmake	/^eLastlyTagThis_ "hello")$/;"	f	line:20	function:Bfunctiontag_this_2.d_ALSO_Tag_this	end:25
+tag_this1	input.cmake	/^function(tag_this1)$/;"	f	line:1	end:2

--- a/Units/parser-cmake.r/cmake-function.d/input.cmake
+++ b/Units/parser-cmake.r/cmake-function.d/input.cmake
@@ -1,5 +1,11 @@
 function(tag_this1)
 endfunction(tag_this1)
+function(a)
+  function(b)
+    function(c)
+    endfunction(c)
+  endfunction(b)
+endfunction(a)
 	function(	Bfunctiontag_this_2 ${BAR})
 
 function(cxx_shared_library name cxx_flags)

--- a/Units/parser-cmake.r/cmake-macro.d/args.ctags
+++ b/Units/parser-cmake.r/cmake-macro.d/args.ctags
@@ -1,0 +1,1 @@
+--fields=+ne

--- a/Units/parser-cmake.r/cmake-macro.d/expected.tags
+++ b/Units/parser-cmake.r/cmake-macro.d/expected.tags
@@ -1,5 +1,8 @@
-Bmacrotag_this_2	input.cmake	/^	macro(	Bmacrotag_this_2 ${BAR})$/;"	m
-cxx_shared_library	input.cmake	/^macro(cxx_shared_library name cxx_flags)$/;"	m
-d_ALSO_Tag_this	input.cmake	/^        d_ALSO_Tag_this$/;"	m
-eLastlyTagThis_	input.cmake	/^eLastlyTagThis_ "hello")$/;"	m
-tag_this1	input.cmake	/^macro(tag_this1)$/;"	m
+Bmacrotag_this_2	input.cmake	/^	macro(	Bmacrotag_this_2 ${BAR})$/;"	m	line:9	end:25
+a	input.cmake	/^function(a)$/;"	f	line:3	end:8
+b	input.cmake	/^  function(b)$/;"	f	line:4	function:a	end:7
+c	input.cmake	/^    function(c)$/;"	f	line:5	function:a.b	end:6
+cxx_shared_library	input.cmake	/^macro(cxx_shared_library name cxx_flags)$/;"	m	line:11	macro:Bmacrotag_this_2	end:13
+d_ALSO_Tag_this	input.cmake	/^        d_ALSO_Tag_this$/;"	m	line:16	macro:Bmacrotag_this_2	end:25
+eLastlyTagThis_	input.cmake	/^eLastlyTagThis_ "hello")$/;"	m	line:20	macro:Bmacrotag_this_2.d_ALSO_Tag_this	end:25
+tag_this1	input.cmake	/^macro(tag_this1)$/;"	m	line:1	end:2

--- a/Units/parser-cmake.r/cmake-macro.d/input.cmake
+++ b/Units/parser-cmake.r/cmake-macro.d/input.cmake
@@ -1,5 +1,11 @@
 macro(tag_this1)
 endmacro(tag_this1)
+function(a)
+  function(b)
+    function(c)
+    endfunction(c)
+  endfunction(b)
+endfunction(a)
 	macro(	Bmacrotag_this_2 ${BAR})
 
 macro(cxx_shared_library name cxx_flags)

--- a/Units/parser-cmake.r/unbalanced-scope.d/input-0.cmake
+++ b/Units/parser-cmake.r/unbalanced-scope.d/input-0.cmake
@@ -1,0 +1,3 @@
+    endmacro(c)
+  endmacro(b)
+endmacro(a)

--- a/Units/parser-cmake.r/unbalanced-scope.d/input.cmake
+++ b/Units/parser-cmake.r/unbalanced-scope.d/input.cmake
@@ -1,0 +1,3 @@
+    endfunction(c)
+  endfunction(b)
+endfunction(a)

--- a/optlib/cmake.c
+++ b/optlib/cmake.c
@@ -22,9 +22,10 @@ static void initializeCMakeParser (const langType language CTAGS_ATTR_UNUSED)
 	addLanguageRegexTable (language, "skipWhiteSpace");
 	addLanguageRegexTable (language, "skipToName");
 	addLanguageRegexTable (language, "nextToken");
+	addLanguageRegexTable (language, "endWithPop");
 
 	addLanguageTagMultiTableRegex (language, "main",
-	                               "^[^sSfFmMaAoOpP# \t\n][^ #\t\n]*[ \t\n]+",
+	                               "^[^eEsSfFmMaAoOpP# \t\n][^ #\t\n]*[ \t\n]+",
 	                               "", "", "", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^#",
@@ -38,6 +39,9 @@ static void initializeCMakeParser (const langType language CTAGS_ATTR_UNUSED)
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^macro[ \t]*\\(",
 	                               "", "", "{icase}{tenter=macro}", NULL);
+	addLanguageTagMultiTableRegex (language, "main",
+	                               "^end(function|macro)[ \t]*\\(",
+	                               "", "", "{icase}{tleave}", NULL);
 	addLanguageTagMultiTableRegex (language, "main",
 	                               "^add_(custom_target|executable|library)[ \t]*\\(",
 	                               "", "", "{icase}{tenter=target}", NULL);
@@ -64,7 +68,7 @@ static void initializeCMakeParser (const langType language CTAGS_ATTR_UNUSED)
 	                               "", "", "{tenter=commentBegin}", NULL);
 	addLanguageTagMultiTableRegex (language, "function",
 	                               "^([A-Za-z_][A-Za-z0-9_]*)([# \t\n\\)])",
-	                               "\\1", "f", "{tleave}{advanceTo=2start}", NULL);
+	                               "\\1", "f", "{advanceTo=2start}{tenter=main,endWithPop}{scope=push}", NULL);
 	addLanguageTagMultiTableRegex (language, "function",
 	                               "^[ \t\n]+",
 	                               "", "", "", NULL);
@@ -73,7 +77,7 @@ static void initializeCMakeParser (const langType language CTAGS_ATTR_UNUSED)
 	                               "", "", "{tenter=commentBegin}", NULL);
 	addLanguageTagMultiTableRegex (language, "macro",
 	                               "^([A-Za-z_][A-Za-z0-9_]*)([# \t\n\\)])",
-	                               "\\1", "m", "{tleave}{advanceTo=2start}", NULL);
+	                               "\\1", "m", "{tleave}{advanceTo=2start}{tenter=main,endWithPop}{scope=push}", NULL);
 	addLanguageTagMultiTableRegex (language, "macro",
 	                               "^[ \t\n]+",
 	                               "", "", "", NULL);
@@ -134,6 +138,9 @@ static void initializeCMakeParser (const langType language CTAGS_ATTR_UNUSED)
 	addLanguageTagMultiTableRegex (language, "nextToken",
 	                               "^[^ \t\n]+[ \t\n]*",
 	                               "", "", "", NULL);
+	addLanguageTagMultiTableRegex (language, "endWithPop",
+	                               "^",
+	                               "", "", "{tleave}{scope=pop}", NULL);
 }
 
 extern parserDefinition* CMakeParser (void)
@@ -180,6 +187,7 @@ extern parserDefinition* CMakeParser (void)
 	def->patterns      = patterns;
 	def->aliases       = aliases;
 	def->method        = METHOD_NOT_CRAFTED|METHOD_REGEX;
+	def->useCork       = 1;
 	def->kindTable = CMakeKindTable;
 	def->kindCount = ARRAY_SIZE(CMakeKindTable);
 	def->initialize    = initializeCMakeParser;

--- a/optlib/cmake.ctags
+++ b/optlib/cmake.ctags
@@ -85,6 +85,7 @@
 --_tabledef-CMake=skipWhiteSpace
 --_tabledef-CMake=skipToName
 --_tabledef-CMake=nextToken
+--_tabledef-CMake=endWithPop
 
 --_mtable-regex-CMake=skipWhiteSpace/[ \t\n]+//
 
@@ -93,6 +94,7 @@
 
 --_mtable-regex-CMake=nextToken/[^ \t\n]+[ \t\n]*//
 
+--_mtable-regex-CMake=endWithPop///{tleave}{scope=pop}
 #
 # main
 #
@@ -100,11 +102,12 @@
 # matching tokens with leading characters that could not possibly match a later regex,
 # and just skipping the whole token (and trailing whitespace). This one regex line
 # improved performance by an order of magnitude.
---_mtable-regex-CMake=main/[^sSfFmMaAoOpP# \t\n][^ #\t\n]*[ \t\n]+//
+--_mtable-regex-CMake=main/[^eEsSfFmMaAoOpP# \t\n][^ #\t\n]*[ \t\n]+//
 --_mtable-extend-CMake=main+skipComment
 --_mtable-regex-CMake=main/set[ \t]*\(//{icase}{tenter=variable}
 --_mtable-regex-CMake=main/function[ \t]*\(//{icase}{tenter=function}
 --_mtable-regex-CMake=main/macro[ \t]*\(//{icase}{tenter=macro}
+--_mtable-regex-CMake=main/end(function|macro)[ \t]*\(//{icase}{tleave}
 --_mtable-regex-CMake=main/add_(custom_target|executable|library)[ \t]*\(//{icase}{tenter=target}
 --_mtable-regex-CMake=main/option[ \t]*\(//{icase}{tenter=option}
 --_mtable-regex-CMake=main/project[ \t]*\(//{icase}{tenter=project}
@@ -130,13 +133,13 @@
 #
 # function
 #
---_mtable-regex-CMake=function/([A-Za-z_][A-Za-z0-9_]*)([# \t\n\)])/\1/f/{tleave}{advanceTo=2start}
+--_mtable-regex-CMake=function/([A-Za-z_][A-Za-z0-9_]*)([# \t\n\)])/\1/f/{advanceTo=2start}{tenter=main,endWithPop}{scope=push}
 --_mtable-extend-CMake=function+skipToName
 
 #
 # macro
 #
---_mtable-regex-CMake=macro/([A-Za-z_][A-Za-z0-9_]*)([# \t\n\)])/\1/m/{tleave}{advanceTo=2start}
+--_mtable-regex-CMake=macro/([A-Za-z_][A-Za-z0-9_]*)([# \t\n\)])/\1/m/{tleave}{advanceTo=2start}{tenter=main,endWithPop}{scope=push}
 --_mtable-extend-CMake=macro+skipToName
 
 #


### PR DESCRIPTION
end: field is implemented. Could you consider merge this change to your pull request IF there is no critical performance impact?

I'm not sure whether function (and/or macro) can be nested.